### PR TITLE
docs(eqnlines): fix typos and minor tweaks

### DIFF
--- a/eqnlines/eqnlines.dtx
+++ b/eqnlines/eqnlines.dtx
@@ -299,12 +299,12 @@ on clarity, readability, adjustability and maintainability
 (but at the cost of moderately higher resource consumption
 and moderately lower efficiency).
 Nevertheless, it remains original \LaTeXe{} code
-without using the expl3 layer.
+without using the \markpkg{expl3} layer.
 \end{itemize}
 %
 
 The package represents a stand-alone implementation
-of an equations environment
+of an |equations| environment
 which is largely compatible with the established \latex/ and \amsmath/
 environments |equation|, |multline|, |gather|, |align|
 and their variants.
@@ -432,7 +432,7 @@ which will be explained further below.
 These follow the scheme |{ !t~ !t* !t! !o !e{@} }|
 according to the syntax of |\NewDocumentCommand|.
 
-We note that the equations environment should be started with a whitespace
+We note that the |equations| environment should be started with a whitespace
 character `\texttt{\textvisiblespace}'
 which provides a clear separation
 from optional arguments `|[|\textit{opts}|]|'
@@ -814,7 +814,7 @@ to assign the number to the last line.
 
 \DescribeInterfaceMacro{\label}
 \DescribeInterfaceMacro{\tag}
-Equation numbers can receive \latex/ labels as usual
+Equation numbers can receive \latex/ labels as usual,
 and they can be turned into manually assigned tags
 using the established macros:
 %
@@ -1166,7 +1166,7 @@ The alignment preset can be adjusted for individual lines by the macros:
 In contradistinction to \amsmath/,
 these macros do not require to specify the cell contents as their argument
 (but there is no harm in doing so).
-The macro accept an optional argument |[|\textit{dimen}|]|
+The macros accept an optional argument |[|\textit{dimen}|]|
 specifying a variable amount of shift.
 \DescribeKey{indent}
 They also accept the modifiers
@@ -1304,7 +1304,7 @@ lists or enumerations to undo an indentation.
 Extending proper punctuation across equations is a delicate matter,
 and maintaining it while redacting the text
 certainly takes more attention to detail
-than many author are willing to afford.
+than many authors are willing to afford.
 A contributing factor is that punctuation marks are harder
 to spot alongside equation context and somewhat out of place anyway.
 
@@ -1314,7 +1314,7 @@ to spot alongside equation context and somewhat out of place anyway.
 The package supplies a semi-automatic scheme by which
 equations are terminated by a specific punctuation mark.
 \unskip\footnote{Clearly, the implementation of the scheme
-will takes higher efforts than direct coding.
+will take higher efforts than direct coding.
 Hence, the scheme can be useful in situations
 where equations typically terminate phrases or
 where punctuation is otherwise expected in regular patterns.}
@@ -1420,7 +1420,7 @@ if the right-hand side is to be broken into several lines:
 For instance, |\\&|\textvisiblespace|+f|
 aligns the subordinate binary operation with the equals sign
 (which may be undesirable).
-Instead placing a phantom equals sign is an effort
+Instead, placing a phantom equals sign is an effort
 that somewhat disrupts the readability of the code.
 
 \DescribeKey{class}
@@ -1797,7 +1797,7 @@ The environment |subequations| groups equations contained in the body
 with a common primary equation number and an extra level
 of numbering (typically: a,\,b,\,c,\,\ldots).
 The numbering layout can be controlled via |subeqtemplate|.
-For instance, the default behaviour of adding lowercase latin letters
+For instance, the default behaviour of adding lowercase Latin letters
 to the parent equation number (|#1|)
 is achieved by:
 %
@@ -1827,7 +1827,7 @@ The environment |intertext| (equivalently the macro |\intertext|)
 injects a (short) line of text
 into a multi-line equation while preserving the equation alignment
 across the text.
-The intertext environment must replace the
+The |intertext| environment must replace the
 end of line marker `|\\|' between two lines of the equation
 (to avoid blank lines).
 The environment accepts several of the vertical spacing adjustments
@@ -1896,7 +1896,7 @@ by a strut, see \secref{sec:vspace}.
 \DescribeInterfaceMacro{\eqnalt}
 The package provides a basic interface to describe the equation content
 in an alternative form for the purposes of accessibility or documentation
-(corresponding to the |alt| tag in html):
+(corresponding to the |alt| tag in HTML):
 %
 \begin{center}
 |alt={|\textit{alt text}|}|
@@ -1905,8 +1905,8 @@ in an alternative form for the purposes of accessibility or documentation
 \end{center}
 %
 At the moment the alternative text \textit{alt} is not processed further,
-but an accessibility extension may implement the feature in tagged pdfs
-or html conversion. The comma-separated optional arguments \textit{opt}
+but an accessibility extension may implement the feature in tagged PDFs
+or HTML conversion. The comma-separated optional arguments \textit{opt}
 may specify the content further:
 |line| and |cell| restrict the applicability
 to the current equation line or cell, respectively.
@@ -2033,10 +2033,10 @@ feature & description \\
 
 Copyright \copyright{} 2024--2025 Niklas Beisert
 
-Based on the latex package amsmath:
+Based on the \latex/ package \amsmath/:
 Copyright \copyright{}
 1995, 2000, 2013 American Mathematical Society;
-2016--2024 LaTeX Project and American Mathematical Society.
+2016--2024 \latex/ Project and American Mathematical Society.
 
 This work may be distributed and/or modified under the
 conditions of the \latex/ Project Public License, either version 1.3
@@ -2069,7 +2069,7 @@ and to the equation number handling in general.
 Michael Downes at the AMS served as coordinator
 for the efforts of Mittelbach, Sch\"opf, and Jones,
 and has contributed various bug fixes and additional refinements over time.
-Since 2016, the package has been maintained by the LaTeX Project
+Since 2016, the package has been maintained by the \latex/ Project
 with contributions by the above and David Carlisle.
 
 This package has been forked from \amsmath/
@@ -2228,11 +2228,11 @@ make |\displaybreak| in text mode adjust initial penalty
 enforce |\raisetag| even if not raised (|\raisetag*|)
 %
 \item
-adjust pdf tagging with development in kernel,
+adjust PDF tagging with development in kernel,
 describe functionality when ready
 %
 \item
-|\intertext| might not collaborate correctly with pdf tagging
+|\intertext| might not collaborate correctly with PDF tagging
 %
 \end{itemize}
 
@@ -2317,7 +2317,7 @@ several issues fixed
 
 \begin{itemize}
 \item
-improvements for pdf tagging
+improvements for PDF tagging
 \item
 backup all available math environments at the start using |backup| switch
 \end{itemize}
@@ -2358,7 +2358,7 @@ padding now applies to single-line equations as well
 
 \begin{itemize}
 \item
-preliminary pdf tagging support
+preliminary PDF tagging support
 (\url{https://latex3.github.io/tagging-project/};
 \amsmath/ \emph{must} be loaded \emph{before} \ctanpkg{eqnlines}
 to avoid errors
@@ -2736,7 +2736,7 @@ preview version published on CTAN
 % \subsection{PDF Tagging Support}
 %
 %   \macro{\eql@tagging@...}
-% Proper pdf tagging
+% Proper PDF tagging
 % \unskip\footnote{see \url{https://latex3.github.io/tagging-project/}}
 % support requires a \latex/ (development) version at least of 2025.
 % For the time being, we define an abstraction layer so that
@@ -3503,7 +3503,7 @@ preview version published on CTAN
 %
 % \TODO describe
 % \TODO would be nice to provide as environments as well
-% \TODO implement for pdf tagging
+% \TODO implement for PDF tagging
 %
 %    \begin{macrocode}
 \DeclareRobustCommand{\eqnalt}[2][]{}
@@ -8526,7 +8526,7 @@ preview version published on CTAN
 %
 %   \macro{\eql@single@start}
 % Opening code for single-line equation.
-% Capture current vertical mode, trigger pdf tagging,
+% Capture current vertical mode, trigger PDF tagging,
 % enter display math mode, initialise numbering scheme,
 % backup current state of global registers,
 % set native vs.\ manual equation tag mode,
@@ -8558,7 +8558,7 @@ preview version published on CTAN
 %   \macro{\eql@single@end}
 % Closing code for single-line equation.
 % Apply punctuation for the block, perform mode-specific ending,
-% restore global variables, end display math, indicate end to pdf tagging,
+% restore global variables, end display math, indicate end to PDF tagging,
 % return to vertical mode if desired:
 %    \begin{macrocode}
 \def\eql@single@end{%
@@ -8608,7 +8608,7 @@ preview version published on CTAN
 %
 %   \macro{\eql@multi@main}
 % Main routine for multi-line modes.
-% Capture current vertical mode, trigger pdf tagging,
+% Capture current vertical mode, trigger PDF tagging,
 % enter display math mode, initialise numbering scheme,
 % backup current state of global registers,
 % initialise macros for use within equations:
@@ -8682,7 +8682,7 @@ preview version published on CTAN
   \eql@display@close
 %    \end{macrocode}
 % Close numbering, restore global variables,
-% end display math, indicate end to pdf tagging,
+% end display math, indicate end to PDF tagging,
 % return to vertical mode if desired:
 %    \begin{macrocode}
   \ifdefined\eql@numbering@subeq@use
@@ -9556,7 +9556,7 @@ preview version published on CTAN
 % \paragraph{Alternative Content Description.}
 %
 % Alternative content description for accessibility or documentation purposes:
-% \TODO implement in pdf tagging
+% \TODO implement in PDF tagging
 %    \begin{macrocode}
 \eql@define@key{equations,equationsbox}{alt}{}
 %    \end{macrocode}
@@ -9877,14 +9877,14 @@ preview version published on CTAN
 % The \latex/ environment |equation| is overwritten by several packages
 % to implement their adjustments.
 % Here we cater for adjustments through \amsmath/, \ctanpkg{hyperref}
-% and the pdf tagging mechanism.
+% and the PDF tagging mechanism.
 % Copy |equation| and |equation*| whenever \amsmath/ is loaded.
 % Whenever \ctanpkg{hyperref} is loaded,
 % and \amsmath/ is not yet present,
 % backup the original \latex/ and \ctanpkg{hyperref} versions of |equation|.
 % If neither \ctanpkg{hyperref} nor \amsmath/ are present,
 % just backup the original \latex/ |equation|.
-% The pdf tagging mechanism registers |equation| upon |\begin{document}|.
+% The PDF tagging mechanism registers |equation| upon |\begin{document}|.
 % We thus need to register all copies of |equation| on our own,
 % so that they can be used with their new names:
 %    \begin{macrocode}
@@ -10178,7 +10178,7 @@ preview version published on CTAN
 % when \amsmath/ or \ctanpkg{hyperref} are loaded.
 % Remove definition of |equation*|
 % before \ctanpkg{amsmath} is loaded in the future to avoid an error.
-% When pdf tagging is active, the environment is modified
+% When PDF tagging is active, the environment is modified
 % at |\begin{document}| in an undesirable fashion,
 % so copy the definition again:
 %    \begin{macrocode}
@@ -10264,7 +10264,7 @@ preview version published on CTAN
 %   \macro{\eql@provide@sqr}
 % Provide the symbolic environment |\[...\]|.
 % Copy into place, and copy again when \amsmath/ is loaded.
-% If pdf tagging is active, some undesired modifications
+% If PDF tagging is active, some undesired modifications
 % happen at |\begin{document}|, so copy again afterwards:
 %    \begin{macrocode}
 \def\eql@provide@sqr{%


### PR DESCRIPTION
Just small things I noticed in the `eqnlines` docs.