### PR TITLE
Add outputdir option to move generated figure files to specified directory

### DIFF
--- a/mpostinl.dtx
+++ b/mpostinl.dtx
@@ -683,6 +683,15 @@ by |\mpostuse| defined by the \ctanpkg{beamer} package.
 (no value implies |true|, initially set to |true|) --
 Enable/disable warnings for unused figure labels.
 
+\item |outputdir=|\textit{dir} --
+Move all generated metapost figure files (|.mps|) to the directory \textit{dir}.
+The directory will be created if it does not exist.
+When displaying figures, the package will first check for files in \textit{dir},
+and fall back to the current directory if not found.
+This allows the same behavior as before:
+on the first pass, a placeholder box with the file path is shown;
+on the second pass, the actual figure is inserted.
+
 \end{itemize}
 %
 Admittedly, some of these options are hardly necessary

--- a/mpostinl/README.txt
+++ b/mpostinl/README.txt
@@ -1,4 +1,4 @@
-mpostinl v1.5.2
+mpostinl v1.5.3
 Copyright 2010-2025 Niklas Beisert
 
 mpostinl is a LaTeX2e package


### PR DESCRIPTION
- Add new package option 'outputdir=dir' to move all generated .mps files to a specified directory
- Automatically create output directory if it doesn't exist
- Update graphics loading to check outputdir first, then fall back to current directory
- Update placeholder file creation to use outputdir when specified
- Move files after compilation in both normal and immediate processing modes
- Update version to v1.5.3